### PR TITLE
🔧 Fix mouse support implementation issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "inquirer>=3.0.0",
     "openpyxl>=3.0.0",
     "pyperclip>=1.8.0",
-    "pynput>=1.7.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
- Remove non-functional mouse support with conflicting terminal escape sequences
- Remove debug print statements from unused mouse methods
- Fix inconsistent print() vs console.print() usage throughout codebase
- Remove pynput dependency and related imports
- Clean up mouse event parsing that conflicted with Rich display
- Simplify copy functionality to keyboard-only (c and space keys)
- Update help text to remove mouse references
- Remove unused mouse variables and methods
- Ensure consistent Rich console output formatting

Issues Fixed:
- Terminal escape sequences (\033[?1000h/l) removed to prevent UI corruption
- Debug prints removed from _on_mouse_click method
- Duplicate error messages eliminated
- Clean separation between keyboard shortcuts and mouse functionality
- Consistent console.print() usage for all user-facing messages

Copy functionality now relies on reliable keyboard shortcuts:
- 'c' key: Copy with truncated display (50 chars + '...')
- 'space' key: Copy full value without truncation